### PR TITLE
Added platform in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.9-jdk11-alpine AS build
+FROM --platform=linux/x86_64 gradle:6.9-jdk11-alpine AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle build --no-daemon


### PR DESCRIPTION
In macs using Apple silicon, the default platform was arm which wasn't working well with the gradle image, so added linux x86_64 platform.

The error message:
![image](https://user-images.githubusercontent.com/29787772/231648416-8db51fa4-fc54-4fd0-b1f3-87d0077aa101.png)
